### PR TITLE
Fixed schematics sometimes being unloaded from the cache before setup

### DIFF
--- a/src/main/java/org/dimdev/dimdoors/shared/pockets/PocketGenerator.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/pockets/PocketGenerator.java
@@ -13,14 +13,24 @@ import java.util.Random;
 
 public final class PocketGenerator {
 
-    public static Pocket generatePocketFromTemplate(int dim, PocketTemplate pocketTemplate, VirtualLocation virtualLocation, boolean setup) {
+    private static Pocket prepareAndPlacePocket(int dim, PocketTemplate pocketTemplate, VirtualLocation virtualLocation, boolean setup) {
         DimDoors.log.info("Generating pocket from template " + pocketTemplate.getId() + " at virtual location " + virtualLocation);
 
-        PocketRegistry registry = PocketRegistry.instance(dim);
-        Pocket pocket = registry.newPocket();
-        pocketTemplate.place(pocket, setup);
-        pocket.setVirtualLocation(virtualLocation);
+        Pocket pocket = PocketRegistry.instance(dim).newPocket();
+	pocketTemplate.place(pocket, setup);
+	pocket.setVirtualLocation(virtualLocation);
+	return pocket;
+    }
+
+    public static Pocket generatePocketFromTemplate(int dim, PocketTemplate pocketTemplate, VirtualLocation virtualLocation, boolean setup) {
+        Pocket pocket = prepareAndPlacePocket(dim, pocketTemplate, virtualLocation, setup);
         if (setup) pocketTemplate.setup(pocket, null, null);
+        return pocket;
+    }
+
+    public static Pocket generatePocketFromTemplate(int dim, PocketTemplate pocketTemplate, VirtualLocation virtualLocation, VirtualTarget linkTo, LinkProperties linkProperties) {
+        Pocket pocket = prepareAndPlacePocket(dim, pocketTemplate, virtualLocation, true);
+        pocketTemplate.setup(pocket, linkTo, linkProperties);
         return pocket;
     }
 
@@ -32,9 +42,7 @@ public final class PocketGenerator {
     // TODO: size of public pockets should increase with depth
     public static Pocket generatePublicPocket(VirtualLocation virtualLocation, VirtualTarget linkTo, LinkProperties linkProperties) {
         PocketTemplate pocketTemplate = SchematicHandler.INSTANCE.getPublicPocketTemplate();
-        Pocket pocket = generatePocketFromTemplate(ModDimensions.getPublicDim(), pocketTemplate, virtualLocation, false);
-        pocketTemplate.setup(pocket, linkTo, linkProperties);
-        return pocket;
+        return generatePocketFromTemplate(ModDimensions.getPublicDim(), pocketTemplate, virtualLocation, linkTo, linkProperties);
     }
 
     /**
@@ -50,8 +58,6 @@ public final class PocketGenerator {
         String group = random.nextFloat() < netherProbability ? "nether" : "ruins";
         PocketTemplate pocketTemplate = SchematicHandler.INSTANCE.getRandomTemplate(group, depth, ModConfig.pockets.maxPocketSize, false);
 
-        Pocket pocket = generatePocketFromTemplate(ModDimensions.getDungeonDim(), pocketTemplate, virtualLocation, false);
-        pocketTemplate.setup(pocket, linkTo, linkProperties);
-        return pocket;
+        return generatePocketFromTemplate(ModDimensions.getDungeonDim(), pocketTemplate, virtualLocation, linkTo, linkProperties);
     }
 }


### PR DESCRIPTION
The current schematic cache system has a chance of unloading schematics after they are placed but before they are set up. This causes [this NPE](https://gist.github.com/TheCodex6824/dec4a2fdde6d48f8a17677e15b63e580) in setup and stops pockets from being generated. The default cache size (10) needs a good bit of dungeon exploring to have this happen, but setting it to 0 will never let any pockets set up. I reorganized the generator code to always ensure that the placement doesn't unload schematics that need to be set up.