### PR TITLE
removed dangerous server crash code!!!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext.forgeversion = "14.23.5.2847"
 String mcpversion = "stable_39"
 
 // Mod version
-version = "3.1.6"
+version = "3.1.7"
 boolean isBeta = false
 group = "org.dimdev.dimdoors"
 archivesBaseName = "DimensionalDoors"

--- a/src/main/java/org/dimdev/dimdoors/shared/EventHandler.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/EventHandler.java
@@ -1,10 +1,8 @@
 package org.dimdev.dimdoors.shared;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.util.DamageSource;
-import net.minecraft.world.World;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -16,8 +14,6 @@ import org.dimdev.dimdoors.shared.world.ModDimensions;
 import static net.minecraft.util.DamageSource.OUT_OF_WORLD;
 
 public final class EventHandler {
-
-    static World world = Minecraft.getMinecraft().world;
 
 
     @SubscribeEvent


### PR DESCRIPTION
static World world = Minecraft.getMinecraft().world; can crash server and I didn't see it until now, my bad for not catching it.