### PR TITLE
More 1.12.2 Fixes and features! Compiled and fully tested

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,7 @@ ext.mcversion = "1.12.2"
 ext.forgeversion = "14.23.5.2860"
 
 // Mod version
-version = "3.0.10"
-boolean isBeta = true
+version = "3.0.11"
 group = "org.dimdev.dimdoors"
 archivesBaseName = "DimensionalDoors"
 
@@ -47,9 +46,6 @@ sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = co
 
 // Build number
 String fullVersion = ext.mcversion + "-" + version
-if (isBeta) {
-    fullVersion += "-b"
-}
 String jarVersion = fullVersion.replace("+", "-") // Github/Travis doesn't seem to support + in filenames
 
 // Configuration

--- a/src/main/java/org/dimdev/dimdoors/shared/EventHandler.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/EventHandler.java
@@ -1,12 +1,21 @@
 package org.dimdev.dimdoors.shared;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.DamageSource;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
+import org.dimdev.ddutils.TeleportUtils;
 import org.dimdev.dimdoors.shared.rifts.registry.RiftRegistry;
+import org.dimdev.dimdoors.shared.sound.ModSounds;
 import org.dimdev.dimdoors.shared.world.ModDimensions;
 
 public final class EventHandler {
@@ -14,8 +23,25 @@ public final class EventHandler {
     @SubscribeEvent(priority = EventPriority.HIGHEST)
     public static void onLivingHurt(LivingHurtEvent event) {
         Entity entity = event.getEntity();
-        if (entity.dimension == ModDimensions.LIMBO.getId() && event.getSource() == DamageSource.FALL) {
+        if (entity.dimension == ModDimensions.getLimboDim() && (event.getSource() == DamageSource.FALL)) {
             event.setCanceled(true);// no fall damage in limbo
+        } else if(entity instanceof EntityPlayer && ModDimensions.isDimDoorsDimension(entity.dimension) && event.getSource() == DamageSource.OUT_OF_WORLD) {
+            event.setCanceled(true);//no void damage for players in dim doors dimensions
+        }
+    }
+
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onLivingDeath(LivingDeathEvent event) {
+        EntityLivingBase entity = event.getEntityLiving();
+        if(entity instanceof EntityPlayer && ModDimensions.isDimDoorsDimension(entity.dimension)) {
+            EntityPlayer player = (EntityPlayer)entity;
+            player.extinguish();
+            if(!player.getActivePotionEffects().isEmpty()) player.clearActivePotions();
+            player.setHealth(entity.getMaxHealth());
+            player.getFoodStats().setFoodLevel(20);
+            player.getFoodStats().setFoodSaturationLevel(6f);
+            teleportToLimbo(player);
+            event.setCanceled(true);
         }
     }
 
@@ -25,5 +51,23 @@ public final class EventHandler {
         if (!ModDimensions.isDimDoorsPocketDimension(event.fromDim) && ModDimensions.isDimDoorsPocketDimension(event.toDim)) {
             RiftRegistry.instance().setOverworldRift(event.player.getUniqueID(), null);
         }
+    }
+
+    /**
+     * Players can no longer fall out of Limbo. Should fix some death related issues and increases the use cases for eternal fabric
+     */
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
+    public static void onPlayerTick(TickEvent.PlayerTickEvent event) {
+        EntityPlayer player = event.player;
+        if (ModDimensions.isDimDoorsDimension(player.dimension) && player.posY<-50) {
+            teleportToLimbo(player);
+        }
+    }
+
+    private static void teleportToLimbo(EntityPlayer player) {
+        double x = player.posX + MathHelper.clamp(player.world.rand.nextDouble(), 100, 100);
+        double z = player.posZ + MathHelper.clamp(player.world.rand.nextDouble(), -100, 100);
+        TeleportUtils.teleport(player, ModDimensions.getLimboDim(),x,700,z,player.rotationYaw,player.rotationPitch);
+        player.world.playSound(null, player.getPosition(), ModSounds.CRACK, SoundCategory.HOSTILE, 13, 1);
     }
 }

--- a/src/main/java/org/dimdev/dimdoors/shared/ModConfig.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/ModConfig.java
@@ -14,6 +14,7 @@ import static net.minecraftforge.common.config.Config.*;
 public final class ModConfig {
 
     public static General general = new General();
+    public static Rifts rifts = new Rifts();
     public static Pockets pockets = new Pockets();
     public static World world = new World();
     public static Dungeons dungeons = new Dungeons();
@@ -40,6 +41,16 @@ public final class ModConfig {
         @RangeDouble(min = 0, max = 3)
         public double teleportOffset = 0.5;
 
+        @Name("depthSpreadFactor")
+        @LangKey("dimdoors.general.depthSpreadFactor")
+        public int depthSpreadFactor = 20;
+
+        @Name("useEnderPearlsInCrafting")
+        @LangKey("dimdoors.general.useEnderPearlsInCrafting")
+        public boolean useEnderPearlsInCrafting = false;
+    }
+
+    public static class Rifts {
         @Name("riftBoundingBoxInCreative")
         @LangKey("dimdoors.general.riftBoundingBoxInCreative")
         public boolean riftBoundingBoxInCreative;
@@ -48,15 +59,6 @@ public final class ModConfig {
         @LangKey("dimdoors.general.riftCloseSpeed")
         @RangeDouble(min = 0)
         public float riftCloseSpeed = 1f;
-
-        @Name("depthSpreadFactor")
-        @LangKey("dimdoors.general.depthSpreadFactor")
-        public int depthSpreadFactor = 20;
-
-        @Name("useEnderPearlsInCrafting")
-        @LangKey("dimdoors.general.useEnderPearlsInCrafting")
-        public boolean useEnderPearlsInCrafting = false;
-
         @Name("enableRiftDecay")
         @LangKey("dimdoors.world.enableDecay")
         public boolean enableRiftDecay = true;
@@ -64,6 +66,14 @@ public final class ModConfig {
         @Name("blockRiftDecayBlackList")
         @LangKey("dimdoors.world.blockDecayBlackList")
         public String[] blockRiftDecayBlackList = {};
+
+        @Name("maxRiftSize")
+        @LangKey("dimdoors.world.maxRiftSize")
+        public int maxRiftSize = -1;
+
+        @Name("enableRifts")
+        @LangKey("dimdoors.world.enableRifts")
+        public boolean enableRifts = true;
     }
 
     public static class Pockets {

--- a/src/main/java/org/dimdev/dimdoors/shared/blocks/BlockFloatingRift.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/blocks/BlockFloatingRift.java
@@ -55,7 +55,7 @@ public class BlockFloatingRift extends BlockSpecialAir implements ITileEntityPro
 
     @Override
     public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, IBlockAccess world, BlockPos pos) {
-        if (ModConfig.general.riftBoundingBoxInCreative) {
+        if (ModConfig.rifts.riftBoundingBoxInCreative) {
             EntityPlayer player = DimDoors.proxy.getLocalPlayer();
             if (player != null && player.isCreative()) {
                 return blockState.getBoundingBox(world, pos);

--- a/src/main/java/org/dimdev/dimdoors/shared/entities/EntityMonolith.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/entities/EntityMonolith.java
@@ -150,11 +150,11 @@ public class EntityMonolith extends EntityFlying implements IMob {
                 if (aggro >= MAX_AGGRO && !world.isRemote && ModConfig.monoliths.monolithTeleportation && !player.isCreative() && isDangerous()) {
                     aggro = 0;
                     Location destination;
-                    if(player.world.provider instanceof WorldProviderLimbo) {
+                    if(player.world.provider instanceof WorldProviderLimbo && world.provider instanceof WorldProviderLimbo) {
                         destination = WorldProviderLimbo.getLimboSkySpawn(player);
                         TeleportUtils.teleport(player, destination, 0, 0);
                     } else {
-                        //If teleport the player to limbo if the player is not already there
+                        //Teleport the player to limbo if the player is not already there
                         //This should fix the crash related to dangerousLimboMonoliths and monolithTeleportation
                         double x = player.posX + MathHelper.clamp(player.world.rand.nextDouble(), 100, 100);
                         double z = player.posZ + MathHelper.clamp(player.world.rand.nextDouble(), -100, 100);

--- a/src/main/java/org/dimdev/dimdoors/shared/pockets/SchematicHandler.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/pockets/SchematicHandler.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.stream.MalformedJsonException;
 import net.minecraft.nbt.CompressedStreamTools;
 import net.minecraft.nbt.NBTTagCompound;
 import org.apache.commons.io.IOUtils;
@@ -77,6 +78,8 @@ public class SchematicHandler { // TODO: parts of this should be moved to the or
             try {
                 String jsonString = IOUtils.toString(file.toURI(), StandardCharsets.UTF_8);
                 templates.addAll(loadTemplatesFromJson(jsonString));
+            } catch (MalformedJsonException e) {
+                DimDoors.log.error("Malformed JSON file for schematic " + file.getName() + ": " + e);
             } catch (IOException e) {
                 DimDoors.log.error("Error reading file " + file.toURI() + ". The following exception occured: ", e);
             }
@@ -92,6 +95,8 @@ public class SchematicHandler { // TODO: parts of this should be moved to the or
                     Schematic.loadFromNBT(CompressedStreamTools.readCompressed(new ByteArrayInputStream (schematicBytecode)));
                     PocketTemplate template = new PocketTemplate(SAVED_POCKETS_GROUP_NAME, file.getName(), null, null, null, null, schematicBytecode, -1, 0);
                     templates.add(template);
+                } catch (MalformedJsonException e) {
+                    DimDoors.log.error("Malformed JSON file for schematic " + file.getName() + ": " + e);
                 } catch (IOException e) {
                     DimDoors.log.error("Error reading schematic " + file.getName() + ": " + e);
                 }

--- a/src/main/java/org/dimdev/dimdoors/shared/tileentities/TileEntityFloatingRift.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/tileentities/TileEntityFloatingRift.java
@@ -66,32 +66,34 @@ import java.util.Random;
             invalidate();
             return;
         }
-
-        if (updateTimer >= UPDATE_PERIOD) {
-            spawnEndermen();
-            updateTimer = 0;
-        } else if (updateTimer == UPDATE_PERIOD / 2) {
-            updateNearestRift();
-        }
-        updateTimer++;
-
-        // Check if this rift should render white closing particles and
-        // spread the closing effect to other rifts nearby.
-        if (closing) {
-            if (size > 0) {
-                size -= ModConfig.general.riftCloseSpeed;
-            } else {
-                world.setBlockToAir(pos);
+        if(ModConfig.rifts.enableRifts) {
+            if (updateTimer >= UPDATE_PERIOD) {
+                spawnEndermen();
+                updateTimer = 0;
+            } else if (updateTimer == UPDATE_PERIOD / 2) {
+                updateNearestRift();
             }
-        } else if (!stabilized) {
-            // Logarithmic growth
-            for (int n = 0; n < 10; n++) {
-                // TODO: growthSpeed and growthSize config options
-                size += 1F / (size + 1);
+            updateTimer++;
+
+            // Check if this rift should render white closing particles and
+            // spread the closing effect to other rifts nearby.
+            if (closing) {
+                if (size > 0) {
+                    size -= ModConfig.rifts.riftCloseSpeed;
+                } else {
+                    world.setBlockToAir(pos);
+                }
+            } else if (!stabilized) {
+                // Logarithmic growth
+                for (int n = 0; n < 10; n++) {
+                    // TODO: growthSpeed and growthSize config options
+                    size += 1F / (size + 1);
+                }
+                //Make blocks around the rift have a random chance of being "unwoven" into world thread
+                if (!world.isRemote && ModConfig.rifts.enableRiftDecay)
+                    RiftDecay.applySpreadDecay(this.world, this.pos, this);
             }
-            //Make blocks around the rift have a random chance of being "unwoven" into world thread
-            if(!world.isRemote && ModConfig.general.enableRiftDecay) RiftDecay.applySpreadDecay(this.world,this.pos,this);
-        }
+        } else world.setBlockToAir(pos);
     }
 
     private void spawnEndermen() {
@@ -222,7 +224,7 @@ import java.util.Random;
         if (curveId < numCurves && curveId >= 0) {
             curve = LSystem.curves.get(curveId);
         } else {
-            // Don't crash if the server sends an invaild curve ID
+            // Don't crash if the server sends an invalid curve ID
             DimDoors.log.error("Curve ID out of bounds (ID: " + curveId + ", number of curves: " + numCurves + ")");
             curve = LSystem.curves.get(0);
         }

--- a/src/main/java/org/dimdev/dimdoors/shared/tileentities/TileEntityRift.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/tileentities/TileEntityRift.java
@@ -153,7 +153,12 @@ import org.dimdev.dimdoors.shared.pockets.PocketTemplate;
 
     public void updateType() {
         if (!isRegistered()) return;
-        Rift rift = RiftRegistry.instance().getRift(new Location(world, pos));
+        Location loc = new Location(world, pos);
+        if(RiftRegistry.instance().isRiftAt(loc)) {
+            DimDoors.log.error("No rift at location "+loc+" to update!");
+            return;
+        }
+        Rift rift = RiftRegistry.instance().getRift(loc);
         rift.isFloating = isFloating();
         rift.markDirty();
     }

--- a/src/main/java/org/dimdev/dimdoors/shared/world/ModDimensions.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/world/ModDimensions.java
@@ -45,6 +45,10 @@ public final class ModDimensions {
         return id == privateDim || id == publicDim || id == dungeonDim;
     }
 
+    public static boolean isDimDoorsDimension(int id) {
+        return id == privateDim || id == publicDim || id == dungeonDim || id == limboDim || id == dungeonMakingDim;
+    }
+
     public static boolean isDimDoorsPocketDimension(World world) {
         return world.provider instanceof WorldProviderPublicPocket
                || world.provider instanceof WorldProviderPersonalPocket

--- a/src/main/java/org/dimdev/dimdoors/shared/world/limbo/WorldProviderLimbo.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/world/limbo/WorldProviderLimbo.java
@@ -96,7 +96,7 @@ public class WorldProviderLimbo extends WorldProvider {
     public static Location getLimboSkySpawn(Entity entity) { // TODO: move this somewhere else
         int x = (int) entity.posX + MathHelper.clamp(entity.world.rand.nextInt(), 100, 100);
         int z = (int) entity.posZ + MathHelper.clamp(entity.world.rand.nextInt(), -100, 100);
-        return new Location(ModDimensions.LIMBO.getId(), x, 700, z);
+        return new Location(ModDimensions.getLimboDim(), x, 700, z);
     }
 
     @Override

--- a/src/main/java/org/dimdev/pocketlib/PocketRegistry.java
+++ b/src/main/java/org/dimdev/pocketlib/PocketRegistry.java
@@ -47,7 +47,7 @@ import org.dimdev.dimdoors.shared.ModConfig;
         MapStorage storage = world.getPerWorldStorage();
         PocketRegistry instance = (PocketRegistry) storage.getOrLoadData(PocketRegistry.class, DATA_NAME);
 
-        if (instance == null) {
+        if (instance == null || instance.pockets==null) {
             instance = new PocketRegistry();
             instance.initNewRegistry();
             storage.setData(DATA_NAME, instance);

--- a/src/main/resources/assets/dimdoors/lang/en_US.lang
+++ b/src/main/resources/assets/dimdoors/lang/en_US.lang
@@ -141,16 +141,22 @@ dimdoors.general.closeDoorBehind=Close Door Behind
 dimdoors.general.closeDoorBehind.tooltip=When true, Dimensional Doors will automatically close when the player enters their portal.
 dimdoors.general.depthSpreadFactor=Depth Spread Factor
 dimdoors.general.depthSpreadFactor.tooltip=The scale of the dispersion when escaping from a pocket or limbo, in blocks/depth. It is important to remember that by default, limbo is treated as depth 50.
-dimdoors.general.riftCloseSpeed=Rift Close Speed
-dimdoors.general.riftCloseSpeed.tooltip=The speed at which rifts close when using the rift remover, in units of rift size per tick.
 dimdoors.general.teleportOffset=Teleport Offset
 dimdoors.general.teleportOffset.tooltip=Distance in blocks to teleport the player in front of the dimensional door.
-dimdoors.general.riftBoundingBoxInCreative=Rift Bounding Box in Creative
-dimdoors.general.riftBoundingBoxInCreative.tooltip=When true, shows the bounding boxes of floating rifts when the player is in creative.
-dimdoors.general.enableRiftDecay=Enable Rift Decay
-dimdoors.general.enableRiftDecay.tooltip=When true, floating rifts will eat nearby placed blocks, dropping world string
-dimdoors.general.blockRiftDecayBlackList=Block Decay Blacklist
-dimdoors.general.blockRiftDecayBlackList.tooltip=A list of blocks that will be blacklisted from rift decay
+
+
+dimdoors.rifts.riftCloseSpeed=Rift Close Speed
+dimdoors.rifts.riftCloseSpeed.tooltip=The speed at which rifts close when using the rift remover, in units of rift size per tick.
+dimdoors.rifts.riftBoundingBoxInCreative=Rift Bounding Box in Creative
+dimdoors.rifts.riftBoundingBoxInCreative.tooltip=When true, shows the bounding boxes of floating rifts when the player is in creative.
+dimdoors.rifts.enableRiftDecay=Enable Rift Decay
+dimdoors.rifts.enableRiftDecay.tooltip=When true, floating rifts will eat nearby placed blocks, dropping world string
+dimdoors.rifts.blockRiftDecayBlackList=Block Decay Blacklist
+dimdoors.rifts.blockRiftDecayBlackList.tooltip=A list of blocks that will be blacklisted from rift decay
+dimdoors.rifts.maxRiftSize=Maximum Rift Size
+dimdoors.rifts.maxRiftSize.tooltip=The maximum size a wild rift can achieve. Set to -1 to ignore. Note that rifts grow logarithmically
+dimdoors.rifts.enableWildRifts=Enable
+dimdoors.rifts.enableWildRifts.tooltip=Determines whether or not wild rifts are enabled
 
 
 dimdoors.pockets=Pocket Dimension Settings


### PR DESCRIPTION
- Fixed a crash related to rift decay
- Improved the rift decay formula and allowed its range to spread as it gets larger
- Attempted to fix the crash related to dangerousLimboMonoliths and monolithTeleportation again
- Added some MalformedJsonException catching when reading in schematic files #125
- Added a catch for null pocket registries #119
- Added some catches when getting a rift from a rift registry #116
- Added a config option to disable wild rifts entirely #239
- Added a config option to set a maximum size for wild rifts #146
- Falling out of Limbo will no longer kill you but instead simulates monolith teleportation #187
- Falling out of or dying in any pocket dimension will now instantly teleport you to Limbo instead of killing you