### PR TITLE
Adds a config option whether blocks decayed by rifts should drop world thread

### DIFF
--- a/src/main/java/org/dimdev/dimdoors/shared/ModConfig.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/ModConfig.java
@@ -59,6 +59,7 @@ public final class ModConfig {
         @LangKey("dimdoors.general.riftCloseSpeed")
         @RangeDouble(min = 0)
         public float riftCloseSpeed = 1f;
+        
         @Name("enableRiftDecay")
         @LangKey("dimdoors.world.enableDecay")
         public boolean enableRiftDecay = true;
@@ -66,7 +67,11 @@ public final class ModConfig {
         @Name("blockRiftDecayBlackList")
         @LangKey("dimdoors.world.blockDecayBlackList")
         public String[] blockRiftDecayBlackList = {};
-
+        
+        @Name("enableRiftDecayDropsWorldThread")
+        @LangKey("dimdoors.world.enableDecayDrops")
+        public boolean enableRiftDecay = true;
+        
         @Name("maxRiftSize")
         @LangKey("dimdoors.world.maxRiftSize")
         public int maxRiftSize = -1;

--- a/src/main/java/org/dimdev/dimdoors/shared/world/RiftDecay.java
+++ b/src/main/java/org/dimdev/dimdoors/shared/world/RiftDecay.java
@@ -85,7 +85,9 @@ public class RiftDecay {
         if (canDecayBlock(block, world, pos)) {
             //change block to air and spawn a new world thread item
             world.setBlockState(pos, Blocks.AIR.getDefaultState());
-            world.spawnEntity(new EntityItem(world,pos.getX(),pos.getY(),pos.getZ(),new ItemStack(ModItems.WORLD_THREAD)));
+            if (ModConfig.rifts.enableRiftDecayDropsWorldThread) {
+                world.spawnEntity(new EntityItem(world,pos.getX(),pos.getY(),pos.getZ(),new ItemStack(ModItems.WORLD_THREAD)));
+            }
             return true;
         }
         return false;

--- a/src/main/resources/assets/dimdoors/lang/en_US.lang
+++ b/src/main/resources/assets/dimdoors/lang/en_US.lang
@@ -184,6 +184,8 @@ dimdoors.world.clusterDimBlacklist=Cluster Dimension Blacklist
 dimdoors.world.clusterDimBlacklist.tooltip=Dimension Blacklist for the generation of Rift Scar clusters. Add a dimension ID here to prevent generation in certain dimensions.
 dimdoors.world.gatewayDimBlacklist=Gateway Dimension Blacklist
 dimdoors.world.gatewayDimBlacklist.tooltip=Dimension Blacklist for the generation of Dimensional Portal gateways. Add a dimension ID here to prevent generation in certain dimensions.
+dimdoors.world.enableDecayDrops=Enable Rift Decay Drops
+dimdoors.world.enableDecayDrops.tooltip=When true, blocks destroyed by rift decay will drop world thread.
 
 dimdoors.dungeons=Dungeon Settings
 dimdoors.dungeons.tooltip=Settings that affect the generation of pocket dungeons


### PR DESCRIPTION
I've made world thread a rare material in my modpack, and i don't want to make it too easy to get.  I presume some other modpack creators may have a similar situation, so I made this config option.  I edited the things i needed to, but i'm unable to test it since i don't have a dev environment set up.  It should work in principle though.