### PR TITLE
Limbo return tweaks and dimension-choice return config options

### DIFF
--- a/common/src/main/java/org/dimdev/dimdoors/ModConfig.java
+++ b/common/src/main/java/org/dimdev/dimdoors/ModConfig.java
@@ -17,6 +17,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -175,10 +176,13 @@ public final class ModConfig implements ConfigData {
 
 		@CollapsibleObject
 		@RequiresRestart
-		@Tooltip private WorldList worldsLeadingToLimbo = new WorldList(List.of(), false);
+		@Tooltip private WorldList worldsLeadingToLimbo = new WorldList();
 		@Tooltip public boolean hardcoreLimbo = false;
 		@Tooltip public int limboReturnDistance = 20000;
-		@Tooltip public float limboBlocksCorruptingOverworldAmount = 5;
+		@Tooltip public float limboBlocksCorruptingExitWorldAmount = 5;
+		@Tooltip public String escapeTargetWorld = "";		
+		@Tooltip public int escapeTargetWorldYSpawn = 64;
+		@Tooltip public boolean escapeToWorldSpawn = false;
 		public boolean shouldUseLimbo(ResourceKey<Level> level) {
 			return worldsLeadingToLimbo.blacklist != worldsLeadingToLimbo.list.contains(level.location().toString());
 		}
@@ -190,6 +194,10 @@ public final class ModConfig implements ConfigData {
 			public WorldList(List<String> list, boolean blacklist) {
 				this.list = list;
 				this.blacklist = blacklist;
+			}
+			
+			public WorldList() {
+				this(new ArrayList<>(), false);
 			}
 		}
 	}

--- a/common/src/main/resources/assets/dimdoors/lang/en_us.json
+++ b/common/src/main/resources/assets/dimdoors/lang/en_us.json
@@ -354,8 +354,8 @@
   "text.autoconfig.dimdoors.option.limbo.universalLimbo.@Tooltip": "When true, players are also teleported to Limbo when they die in any non-Pocket Dimension (except Limbo itself). Otherwise, players only go to Limbo if they die in a Pocket Dimension.",
   "text.autoconfig.dimdoors.option.limbo.hardcoreLimbo": "Hardcore Limbo",
   "text.autoconfig.dimdoors.option.limbo.hardcoreLimbo.@Tooltip": "When true, a player dying in Limbo will respawn in Limbo, making Eternal Fluid or Golden Dimensional Doors the only way to escape Limbo.",
-  "text.autoconfig.dimdoors.option.limbo.limboBlocksCorruptingOverworldAmount": "Overworld Decay Radius",
-  "text.autoconfig.dimdoors.option.limbo.limboBlocksCorruptingOverworldAmount.@Tooltip": "The radius around a player in which blocks can decay upon exiting limbo.",
+  "text.autoconfig.dimdoors.option.limbo.limboBlocksCorruptingExitWorldAmount": "Exit World Decay Radius",
+  "text.autoconfig.dimdoors.option.limbo.limboBlocksCorruptingExitWorldAmount.@Tooltip": "The radius around a player in which blocks can decay upon exiting limbo.",
   "text.autoconfig.dimdoors.option.limbo.worldsLeadingToLimbo": "Worlds Leading to Limbo",
   "text.autoconfig.dimdoors.option.limbo.worldsLeadingToLimbo.@Tooltip": "Defines a blacklist/whitelist of worlds that will send the player to limbo upon death.",
   "text.autoconfig.dimdoors.option.limbo.worldsLeadingToLimbo.list": "List of world ids",
@@ -364,7 +364,13 @@
   "text.autoconfig.dimdoors.option.limbo.worldsLeadingToLimbo.blacklist.@Tooltip": "Boolean that determines if list is a blacklist or white list for worlds.",
   "text.autoconfig.dimdoors.option.limbo.limboReturnDistance.@Tooltip": "Distance from spawn that limbo returns you",
   "text.autoconfig.dimdoors.option.limbo.limboReturnDistance": "Limbo Return Radius",
-
+  "text.autoconfig.dimdoors.option.limbo.escapeTargetWorld": "Escape To World",
+  "text.autoconfig.dimdoors.option.limbo.escapeTargetWorld.@Tooltip": "Defines the id of the world players will spawn in upon exiting Limbo.  Leaving this blank will spawn players in the world their respawn point is in.",
+  "text.autoconfig.dimdoors.option.limbo.escapeTargetWorldYSpawn": "Escape To World Y Level",
+  "text.autoconfig.dimdoors.option.limbo.escapeTargetWorldYSpawn.@Tooltip": "Defines the Y coordinate the player will spawn at when using \"Escape To World\"",
+  "text.autoconfig.dimdoors.option.limbo.escapeToWorldSpawn": "Escape to World Spawn",
+  "text.autoconfig.dimdoors.option.limbo.escapeToWorldSpawn.@Tooltip": "Boolean that determines if players exiting limbo will return relative to the worldspawn instead.  If true, escapeTargetWorld has no effect.",
+  
 
 
   "text.autoconfig.dimdoors.category.graphics": "Graphics Settings",


### PR DESCRIPTION
- Added config options for choosing which dimension the player will spawn in upon exiting limbo
- Players returning from limbo will spawn inside two air blocks to prevent suffocation in case they spawn inside terrain
- Players falling in the air will not take damage when landing after returning from limbo
- Limbo config options should no longer reset on game launch [Thanks @shedaniel :)]
(Side note: renamed the option `limboBlocksCorruptingOverworldAmount` to `limboBlocksCorruptingExitWorldAmount`)
Let me know if something doesn't work right, but this _should_ be good to go.  Thanks!