### PR TITLE
Fabric of reality can be mined again with the silk touch

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/mineable/pickaxe.json
@@ -4,6 +4,22 @@
     "dimdoors:stone_player",
     "dimdoors:gold_door",
     "dimdoors:quartz_door",
-    "dimdoors:solid_static"
+    "dimdoors:solid_static",
+    "dimdoors:black_fabric",
+    "dimdoors:yellow_fabric",
+    "dimdoors:orange_fabric",
+    "dimdoors:white_fabric",
+    "dimdoors:red_fabric",
+    "dimdoors:green_fabric",
+    "dimdoors:brown_fabric",
+    "dimdoors:blue_fabric",
+    "dimdoors:light_blue_fabric",
+    "dimdoors:lime_fabric",
+    "dimdoors:pink_fabric",
+    "dimdoors:gray_fabric",
+    "dimdoors:purple_fabric",
+    "dimdoors:cyan_fabric",
+    "dimdoors:magenta_fabric",
+    "dimdoors:light_gray_fabric"
   ]
 }


### PR DESCRIPTION
Back on 1.20.1, I noticed that I couldn't get these blocks with a pickaxe. It seemed like it was possible in the original version