### PR TITLE
Make `riftJitter` setting affect all motion

### DIFF
--- a/common/src/main/java/org/dimdev/dimdoors/client/RiftCrackRenderer.java
+++ b/common/src/main/java/org/dimdev/dimdoors/client/RiftCrackRenderer.java
@@ -44,7 +44,7 @@ public final class RiftCrackRenderer {
 
         // generate a series of waveforms
         for (int i = 0; i < jCount; i += 1) {
-            jitters[i] = Math.sin((1F + i / 10F) * time) * Math.cos(1F - i / 10F * time) * motionMagnitude;
+            jitters[i] = jitterScale * Math.sin((1F + i / 10F) * time) * Math.cos(1F - i / 10F * time) * motionMagnitude;
         }
 
         // Draw the rift


### PR DESCRIPTION
Change rift jitter so that motion properly respects the `riftJitter` Graphics setting, and is disabled if the setting has a value of zero.